### PR TITLE
Optimise image generation and add benchmarking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +42,18 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -51,10 +74,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "cast"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "bitflags",
+ "textwrap",
+ "unicode-width",
+]
 
 [[package]]
 name = "color_quant"
@@ -69,6 +112,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+dependencies = [
+ "cast",
+ "itertools",
 ]
 
 [[package]]
@@ -113,6 +192,28 @@ checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if",
  "lazy_static",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -257,6 +358,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +437,12 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
@@ -405,6 +533,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "pin-project"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +556,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -526,6 +688,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scoped_threadpool"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +743,50 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+
+[[package]]
+name = "serde"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+dependencies = [
+ "itoa 1.0.1",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "smallvec"
@@ -564,6 +815,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "threadpool"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,18 +844,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ulam"
 version = "0.3.0"
 dependencies = [
+ "criterion",
  "image",
  "primal",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -658,7 +946,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
+name = "web-sys"
+version = "0.3.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b77fdfd5a253be4ab714e4ffa3c49caf146b4de743e97510c0656cf90f1e8e"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,10 @@ img = ["image", "primal"]
 [dependencies]
 image = { version = "0.24.1", optional = true }
 primal = { version = "0.3.0", optional = true }
+
+[dev-dependencies]
+criterion = "0.3.5"
+
+[[bench]]
+name = "image_benchmark"
+harness = false

--- a/benches/image_benchmark.rs
+++ b/benches/image_benchmark.rs
@@ -1,0 +1,15 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ulam::ulamspiral_img::generate;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    // let mut group = c.benchmark_group("generation");
+    c.bench_function("generate 10,000 x 10,000", |b| {
+        b.iter(|| generate(black_box(10_000), black_box(10_000)))
+    });
+    // group.bench_function("generate 10,000 x 10,000 old", |b| {
+    //     b.iter(|| generate_old(black_box(10_000), black_box(10_000)))
+    // });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,18 +297,3 @@ mod tests {
         assert_eq!(result, 3990755);
     }
 }
-
-// pub fn quad_of_coord(c: &Coord) -> Quad {
-//     match (c.x == c.y, c.x == -c.y, c.x > 0, c.y > 0) {
-//         (true, false, true, true) => Quad::NorthEast,
-//         (true, false, false, false) => Quad::SouthWest,
-//         (false, true, false, true) => Quad::NorthWest,
-//         (false, true, true, false) => Quad::SouthEast,
-//         _ => match (c.x > c.y, c.x > -c.y) {
-//             (true, true) => Quad::East,
-//             (false, false) => Quad::West,
-//             (false, true) => Quad::North,
-//             (true, false) => Quad::South
-//         }
-//     }
-// }

--- a/src/ulamspiral_img.rs
+++ b/src/ulamspiral_img.rs
@@ -1,29 +1,30 @@
-pub fn generate(x_size: u32, y_size: u32) -> image::ImageBuffer<image::Luma<u8>, Vec<u8>> {
-    if x_size == 0 || y_size == 0 {
-        return image::ImageBuffer::new(0, 0);
-    }
-    // assert!(x_size > 0 && y_size > 0, "inputs must be greater than 0");
+use std::{cmp, error::Error};
 
+pub fn generate(
+    x_size: u32,
+    y_size: u32,
+) -> Result<image::ImageBuffer<image::Luma<u8>, Vec<u8>>, Box<dyn Error>> {
     let mut img = image::ImageBuffer::new(x_size, y_size);
-    let x_size = x_size as i32;
-    let y_size = y_size as i32;
+    let total = u64::from(cmp::max(x_size, y_size)).pow(2).try_into()?;
+    let sieve = primal::Sieve::new(total);
 
-    for x in (0..x_size).map(|x| x - x_size / 2) {
-        for y in (0..y_size).map(|y| y - y_size / 2) {
-            let coord = crate::Coord::new(x, y);
-            let deets = crate::get_ulam_deets(&coord);
-            let value = deets.value;
-            if primal::is_prime(value as u64) {
-                let pixel = image::Luma::from([255 as u8]);
-                img.put_pixel(
-                    (x_size / 2 + x) as u32,
-                    ((y_size - y_size / 2) - y - 1) as u32,
-                    pixel,
-                );
-            }
+    for prime in sieve.primes_from(0).take_while(|x| *x <= total) {
+        let coord = crate::lookup::lookup(prime.try_into()?);
+        let pos_x: i64 = i64::from(x_size) - i64::from(x_size) / 2 + i64::from(coord.x);
+        let pos_y: i64 = (i64::from(y_size) / 2 - i64::from(coord.y)) + 1;
+        if pos_x < 1
+            || u32::try_from(pos_x)? > x_size
+            || pos_y < 1
+            || u32::try_from(pos_y)? > y_size
+        {
+            // A rectangle is being generated and this prime lies outside it.
+            continue;
         }
+        let pixel = image::Luma::from([255]);
+        img.put_pixel(u32::try_from(pos_x)? - 1, u32::try_from(pos_y)? - 1, pixel)
     }
-    img
+
+    Ok(img)
 }
 
 #[cfg(test)]
@@ -31,7 +32,7 @@ mod tests {
     use super::*;
     #[test]
     fn check_sq() {
-        let odd = generate(5, 5);
+        let odd = generate(5, 5).unwrap();
         let mut expected_odd = image::ImageBuffer::new(5, 5);
         expected_odd.put_pixel(3, 0, image::Luma::from([255 as u8]));
         expected_odd.put_pixel(0, 1, image::Luma::from([255 as u8]));
@@ -44,26 +45,25 @@ mod tests {
         expected_odd.put_pixel(3, 4, image::Luma::from([255 as u8]));
         assert_eq!(odd, expected_odd);
 
-        let even = generate(4, 4);
+        let even = generate(4, 4).unwrap();
         let mut expected_even = image::ImageBuffer::new(4, 4);
-        expected_even.put_pixel(0, 0, image::Luma::from([255 as u8]));
         expected_even.put_pixel(2, 0, image::Luma::from([255 as u8]));
-        expected_even.put_pixel(3, 0, image::Luma::from([255 as u8]));
         expected_even.put_pixel(1, 1, image::Luma::from([255 as u8]));
+        expected_even.put_pixel(2, 1, image::Luma::from([255 as u8]));
+        expected_even.put_pixel(3, 1, image::Luma::from([255 as u8]));
         expected_even.put_pixel(0, 2, image::Luma::from([255 as u8]));
-        expected_even.put_pixel(2, 2, image::Luma::from([255 as u8]));
-        expected_even.put_pixel(3, 3, image::Luma::from([255 as u8]));
+        expected_even.put_pixel(1, 3, image::Luma::from([255 as u8]));
         assert_eq!(even, expected_even);
     }
     #[test]
     fn check_bad() {
-        let bad = generate(0, 1);
-        let img = image::ImageBuffer::new(0, 0);
-        assert_eq!(bad, img);
+        let bad = generate(0, 1).unwrap();
+        let expected = image::ImageBuffer::new(0, 1);
+        assert_eq!(bad, expected);
     }
     #[test]
     fn check_rect() {
-        let tall = generate(5, 3);
+        let tall = generate(5, 3).unwrap();
         let mut expected_tall = image::ImageBuffer::new(5, 3);
         expected_tall.put_pixel(0, 0, image::Luma::from([255 as u8]));
         expected_tall.put_pixel(2, 0, image::Luma::from([255 as u8]));
@@ -74,7 +74,7 @@ mod tests {
         expected_tall.put_pixel(2, 2, image::Luma::from([255 as u8]));
         assert_eq!(tall, expected_tall);
 
-        let wide = generate(3, 5);
+        let wide = generate(3, 5).unwrap();
         let mut expected_wide = image::ImageBuffer::new(3, 5);
         expected_wide.put_pixel(2, 0, image::Luma::from([255 as u8]));
         expected_wide.put_pixel(1, 1, image::Luma::from([255 as u8]));

--- a/src/ulamspiral_img.rs
+++ b/src/ulamspiral_img.rs
@@ -21,7 +21,7 @@ pub fn generate(
             continue;
         }
         let pixel = image::Luma::from([255]);
-        img.put_pixel(u32::try_from(pos_x)? - 1, u32::try_from(pos_y)? - 1, pixel)
+        img.put_pixel(u32::try_from(pos_x)? - 1, u32::try_from(pos_y)? - 1, pixel);
     }
 
     Ok(img)


### PR DESCRIPTION
Iterating over primes using a sieve and using the new lookup function for each increased performance by 28x for a 10,000^2 size spiral. The old method iterated over every number in the grid and checked if it was prime.

Problem - I tested at a size of 50,000^2 and couldn't reach this due to overflow errors outside the generate function. I don't know if it's worth supporting images this large but you can reproduce @miketwenty1 if you're interested in fixing this.

![image](https://user-images.githubusercontent.com/100003152/155884510-6d76ea3b-6a2e-4983-8c7c-87b23b57126e.png)
