### PR TITLE
Make Coord fields public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@ pub struct UlamPoint {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Coord {
-    x: i32,
-    y: i32,
+    pub x: i32,
+    pub y: i32,
 }
 
 impl Coord {


### PR DESCRIPTION
With the new lookup feature, Coord fields must be public otherwise the results cannot be used.
(No version bump this time)