### PR TITLE
Improve ulamspiral_img internal readability

### DIFF
--- a/src/ulamspiral_img.rs
+++ b/src/ulamspiral_img.rs
@@ -7,6 +7,7 @@ pub fn generate(
     let mut img = image::ImageBuffer::new(x_size, y_size);
     let total = u64::from(cmp::max(x_size, y_size)).pow(2).try_into()?;
     let sieve = primal::Sieve::new(total);
+    let pixel = image::Luma::from([255]);
 
     for prime in sieve.primes_from(0).take_while(|x| *x <= total) {
         let coord = crate::lookup::lookup(prime.try_into()?);
@@ -20,7 +21,6 @@ pub fn generate(
             // A rectangle is being generated and this prime lies outside it.
             continue;
         }
-        let pixel = image::Luma::from([255]);
         img.put_pixel(u32::try_from(pos_x)? - 1, u32::try_from(pos_y)? - 1, pixel);
     }
 

--- a/src/ulamspiral_img.rs
+++ b/src/ulamspiral_img.rs
@@ -10,7 +10,6 @@ pub fn generate(
     let pixel = image::Luma::from([255]);
 
     for prime in sieve.primes_from(0).take_while(|x| *x <= total) {
-
         let coord = crate::calc_coord::calc(prime.try_into()?);
         let pos_x: i64 = i64::from(x_size) - i64::from(x_size) / 2 + i64::from(coord.x);
         let pos_y: i64 = (i64::from(y_size) / 2 - i64::from(coord.y)) + 1;

--- a/src/ulamspiral_img.rs
+++ b/src/ulamspiral_img.rs
@@ -12,7 +12,7 @@ pub fn generate(
     for prime in sieve.primes_from(0).take_while(|x| *x <= total) {
         let coord = crate::calc_coord::calc(prime.try_into()?);
         let pos_x: i64 = i64::from(x_size) - i64::from(x_size) / 2 + i64::from(coord.x);
-        let pos_y: i64 = (i64::from(y_size) / 2 - i64::from(coord.y)) + 1;
+        let pos_y: i64 = i64::from(y_size) / 2 - i64::from(coord.y) + 1;
         if pos_x < 1
             || u32::try_from(pos_x)? > x_size
             || pos_y < 1


### PR DESCRIPTION
I removed a line of unnecessary whitespaced and 'cached' `pixel` outside the for loop, which works since it's `Copy`. I don't know what affect (if any) this will have on performance and memory usage, but the effect is insignificant.